### PR TITLE
Second proofreading pass

### DIFF
--- a/includes/etude-op25-no1-parts.ily
+++ b/includes/etude-op25-no1-parts.ily
@@ -84,7 +84,7 @@ rightHand = \relative ef'' {
       \ns bf'16 c, ef ef, c' ef  \ns af c, ef ef, c' ef
         \ns af c, e e, c' e  \ns af c, e e, c' e) |
       \ns af16(-5 df, f af, df f  \ns af-4 df, f af, df f
-        \ns af df, f af, df f  \ns bf df, f af, df f |
+        \ns af df, f af, df f  \ns bf df, f g, df' f |
       \ns c'16 c,-2 f g, c f-4  \ns g-5 c, f g, c f
         \ns g c, e g, c e  \ns g c, e g, c e) |
       \ns g16( b, e-4 f, b e  \ns g b, d-3 f, b d

--- a/includes/etude-op25-no11-parts.ily
+++ b/includes/etude-op25-no11-parts.ily
@@ -213,7 +213,7 @@ rightHand = \relative {
   <f b>8-.) r r4 |
   \scaleDurations 2/3 {
     \ottava 1 b'16( f as d, a' f  gs d g d fs b,  \ottava 0 f' b, e gs, ds' b
-      d gs, cs gs c fs, |
+      d gs, cs gs c f, |
     b16 f as d, a' f  gs d g d fs b,
   }
   <gs d' f>8-.) r r4 |

--- a/includes/etude-op25-no4-parts.ily
+++ b/includes/etude-op25-no4-parts.ily
@@ -198,7 +198,7 @@ rightHandLower = \relative {
 rightHand = <<
   \clef treble
   \global
-  \tempo "Agitato" 4 = 160
+  \tempo "Agitato" 4 = 120
   \new Voice \rightHandUpper
   \new Voice \rightHandLower
 >>
@@ -212,7 +212,7 @@ leftHand = \relative {
   c,8-. <a' f'>-. c,-. <a' e'>-. b,-. <f' d'>-. e,-. <e' b' d>-. |
   a,8-. <e' c'>-. b-. <e d'>-. c-. <e e'>-. a,-. <e' c'>-. |
   e,8-. <e' d'>-. a,-. <e' c'>-. b-. <e gs d'>-. a,-. <e' a c>-. |
-  e,8-. <e' gs d'>-. a,-. <e' a c>-.  b-. <e gs d'> a,-. <e' a c>-. |
+  e,8-. <e' gs d'>-. a,-. <e' a c>-.  b-. <e gs d'>-. a,-. <e' a c>-. |
   g,8-. <g' e'>-. a,-. <a' e'>-. b,-. <b' e>-. b,-. <b' ds>-. |
   e,8-. <b' e>-. ds,-. <c' fs>-. d,-. <b' f'>-. e,,-. <b'' e>-. |
   

--- a/includes/etude-op25-no6-parts.ily
+++ b/includes/etude-op25-no6-parts.ily
@@ -111,9 +111,9 @@ rightHand = \relative {
   <b ds>16_1 <cs e>_2 <b ds>_1 <as css>-2-3  <b ds> <cs e> <b ds> <as css>
     <b ds> <cs e> <b ds> <as css>  <b ds>-1-4 <cs e>-2-5 <b ds>-1-4( 
     <as css>-2-4) |
-  <b ds>16 <cs e> <css es>-5 <ds fs>  <dss fss>_1 <e gs>_1 <fs a> <fss as>
-    <gs b> <gss bs>-5 <as cs> <ass css>_1  <b ds>_1 <cs e> <css es>-5 <ds fs> |
-  \ottava 1 <dss fss>16 <e gs> <fs a> <fss as>  <gs b>8\) \ottava 0 r r2 |
+  <b ds>16 <cs e> <css es>-5 <ds fs>  <dss fss>_1 <es gs>_1 <fs a> <fss as>
+    <gs b> <gss bs>-5 <as cs> <ass css>_1  <bs ds>_1 <cs e> <css es>-5 <ds fs> |
+  \ottava 1 <dss fss>16 <es gs> <fs a> <fss as>  <gs b>8\) \ottava 0 r r2 |
   <d, f>16-1-4( <e g>-2-5 \repeat unfold 7 { <d f> <e g> } |
   <d f>16_1 <e g>_2 <d f>_1 <cs e>-2-3
     \repeat unfold 3 { <d f> <e g> <d f> <cs e> } |

--- a/includes/etude-op25-no8-parts.ily
+++ b/includes/etude-op25-no8-parts.ily
@@ -98,7 +98,7 @@ rightHand = \relative {
     <ef cf'>8 <f df'> <ef cf'>  <f df'> <ef cf'> <cf af'>  <df bf'> <bf gf'>
       <df bf'>-2-5-\slurShapeB ^(  <c af'>-2-5) <gf ef'> <af f'>\) |
     <f df'>8(-1-4 <fs d'>-2-5 <g ef'>-1-4  <gs e'>-2-5 <a f'>-1-5 <as fs'>-2-4
-      <b g'>-1-5 <c af'>-1-4 <cs a'>-2-5  <df bf'>-1-4 <ds b'>-2-5 <e c'>-1-5 |
+      <b g'>-1-5 <c af'>-1-4 <cs a'>-2-5  <d bf'>-1-4 <ds b'>-2-5 <e c'>-1-5 |
     
     \barNumberCheck 33
     <f df'>8-1-4 <fs d'>-2-5 <g ef'>-1-4  <gs e'>-2-5 <a f'>-1-5 <as fs'>-2-4


### PR DESCRIPTION
I found just a few more changes to make to align with the Mikuli edition. The commits are split up according to the piece being modified, as before.

* Op.25 No.1: This fix is identical to my previous fix, but in a later, analogous measure.
* Op.25 No.4: Align the metronome mark BPM to that from Mikuli, and add a missing staccato mark (detecting from listening to the MIDI file).
* Op.25 No.6: There were three incorrect notes (with missing sharps) in one of the ascending chromatic-third passages.
* Op.25 No.8: There was one incorrect note in the final ascending chromatic-sixth passage.
* Op.25 No.11: There was one incorrect note in a sequence that outlines a fully-diminished seventh chord (G-sharp/B/D/F) with the descending chromatic line interleaved.